### PR TITLE
Use HTTMultiParty to support file uploads

### DIFF
--- a/greenhouse.gemspec
+++ b/greenhouse.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency('httparty')
+  spec.add_dependency('httmultiparty')
   spec.add_dependency('multi_json', '~> 1.8.0')
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/lib/greenhouse.rb
+++ b/lib/greenhouse.rb
@@ -1,4 +1,4 @@
-require 'httparty'
+require 'httmultiparty'
 require 'multi_json'
 require 'cgi'
 

--- a/lib/greenhouse/api.rb
+++ b/lib/greenhouse/api.rb
@@ -2,7 +2,7 @@ module Greenhouse
   class API
     attr_accessor :api_token, :organization
 
-    include HTTParty
+    include HTTMultiParty
     base_uri 'https://api.greenhouse.io/v1'
 
     def initialize(api_token = nil, default_options = {})


### PR DESCRIPTION
`HTTMultiParty` is a drop-in replacement for `HTTParty` which adds support for multipart/form-data.
