### PR TITLE
adding job_ids ( the new request parameter for applications )

### DIFF
--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -3,7 +3,7 @@ module GreenhouseIo
     include HTTMultiParty
     include GreenhouseIo::API
 
-    PERMITTED_OPTIONS = [:page, :per_page]
+    PERMITTED_OPTIONS = [:page, :per_page, :job_id]
 
     attr_accessor :api_token, :rate_limit, :rate_limit_remaining
     base_uri 'https://harvest.greenhouse.io/v1'

--- a/lib/greenhouse_io/version.rb
+++ b/lib/greenhouse_io/version.rb
@@ -1,3 +1,3 @@
 module GreenhouseIo
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
There is a new request parameter for searching applications:

job_id	No	string	If supplied, only return applications that involve this job. It will return both candidates and prospects. 