### PR TITLE
Allow new version of multi_json

### DIFF
--- a/greenhouse_io.gemspec
+++ b/greenhouse_io.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency('httmultiparty')
-  spec.add_dependency('multi_json', '>= 1.9.2', '<= 1.10.1')
+  spec.add_dependency('multi_json', '>= 1.9.2')
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Any special reason you sticking with `1.10.1` ?
(I had do downgrade today my version of `multi_json` in order to use this gem)