### PR TITLE
Upgrade dependencies

### DIFF
--- a/greenhouse_io.gemspec
+++ b/greenhouse_io.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency('httmultiparty')
-  spec.add_dependency('multi_json', '>= 1.9.2', '<= 1.10.1')
+  spec.add_dependency('multi_json', '~>1.11.2')
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 2.14.1"
-  spec.add_development_dependency "webmock", "~> 1.8.0"
-  spec.add_development_dependency "vcr", "~> 2.5.0"
+  spec.add_development_dependency "rspec", "~> 3.4.0"
+  spec.add_development_dependency "webmock", "~> 1.22.6"
+  spec.add_development_dependency "vcr", "~> 3.0.1"
 end

--- a/spec/greenhouse_io/configuration_spec.rb
+++ b/spec/greenhouse_io/configuration_spec.rb
@@ -9,7 +9,7 @@ describe GreenhouseIo::Configuration do
     end
 
     it "returns the default value" do
-      expect(GreenhouseIo.configuration.symbolize_keys).to be_false
+      expect(GreenhouseIo.configuration.symbolize_keys).to be false
     end
   end
 
@@ -21,7 +21,7 @@ describe GreenhouseIo::Configuration do
     end
 
     it "returns the specified value" do
-      expect(GreenhouseIo.configuration.symbolize_keys).to be_true
+      expect(GreenhouseIo.configuration.symbolize_keys).to be true
     end
   end
 


### PR DESCRIPTION
Update old gems.

In rpsec 3.0, the behavior of be_true has changed and was renamed be_truthy. Updated tests to use `be true` and `be false` instead.