### PR TITLE
Add Offers API

### DIFF
--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -16,6 +16,10 @@ module GreenhouseIo
       get_from_harvest_api "/offices#{path_id(id)}", options
     end
 
+    def offers(id = nil, options = {})
+      get_from_harvest_api "/offers#{path_id(id)}", options
+    end
+
     def departments(id = nil, options = {})
       get_from_harvest_api "/departments#{path_id(id)}", options
     end

--- a/spec/fixtures/cassettes/client/offer.yml
+++ b/spec/fixtures/cassettes/client/offer.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://123FakeToken:@harvest.greenhouse.io/v1/offers/221598
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 27 Jan 2016 00:27:44 GMT
+      Status:
+      - 200 OK
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '400'
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Content-Type-Options:
+      - nosniff
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"id":221598,"version":1,"application_id":21708586,"created_at":"2016-01-26T23:57:28Z","sent_at":null,"resolved_at":"2016-01-26T23:57:35Z","starts_at":"2016-01-26","status":"rejected","custom_fields":{"benefits":"Full
+        Medical","bonus":"1000","current_salary":"25000","employment_type":"Full-time","notes":"He
+        was very excited.","options":"2000","salary":"31000","source_cost":null,"visa_cost":"200"}}'
+    http_version: 
+  recorded_at: Wed, 27 Jan 2016 00:27:44 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/offers.yml
+++ b/spec/fixtures/cassettes/client/offers.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://123FakeToken:@harvest.greenhouse.io/v1/offers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 26 Jan 2016 23:59:58 GMT
+      Status:
+      - 200 OK
+      Content-Type:
+      - application/json;charset=utf-8
+      Link:
+      - <https://harvest.greenhouse.io/v1/offers?page=1&per_page=100>; rel="last"
+      Content-Length:
+      - '1517'
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Content-Type-Options:
+      - nosniff
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"id":221598,"version":1,"application_id":21708586,"created_at":"2016-01-26T23:57:28Z","sent_at":null,"resolved_at":"2016-01-26T23:57:35Z","starts_at":"2016-01-26","status":"rejected","custom_fields":{"benefits":"Full
+        Medical","bonus":"1000","current_salary":"25000","employment_type":"Full-time","notes":"He
+        was very excited.","options":"2000","salary":"31000","source_cost":null,"visa_cost":"200"}},{"id":221603,"version":1,"application_id":21880506,"created_at":"2016-01-26T23:59:27Z","sent_at":null,"resolved_at":null,"starts_at":"2016-01-30","status":"unresolved","custom_fields":{"benefits":null,"bonus":"1000","current_salary":null,"employment_type":"Full-time","notes":null,"options":"2000","salary":"60000","source_cost":null,"visa_cost":null}},{"id":163831,"version":1,"application_id":22109366,"created_at":"2015-11-30T22:29:19Z","sent_at":null,"resolved_at":"2015-11-30T22:29:52Z","starts_at":"2015-12-01","status":"accepted","custom_fields":{"benefits":null,"bonus":null,"current_salary":null,"employment_type":"Full-time","notes":null,"options":null,"salary":"20000","source_cost":null,"visa_cost":null}},{"id":221601,"version":1,"application_id":24709881,"created_at":"2016-01-26T23:58:48Z","sent_at":null,"resolved_at":"2016-01-26T23:59:07Z","starts_at":"2016-01-19","status":"accepted","custom_fields":{"benefits":null,"bonus":"1000","current_salary":"500","employment_type":"Full-time","notes":"He
+        didn''t seem too impressed.","options":"100","salary":"74111","source_cost":"200","visa_cost":null}}]'
+    http_version: 
+  recorded_at: Tue, 26 Jan 2016 23:59:58 GMT
+recorded_with: VCR 3.0.1

--- a/spec/greenhouse_io/api/client_spec.rb
+++ b/spec/greenhouse_io/api/client_spec.rb
@@ -491,6 +491,26 @@ describe GreenhouseIo::Client do
           expect(@offers.first[:status]).to be_a(String)
         end
       end
+
+      context "given an id" do
+        before do
+          VCR.use_cassette('client/offer') do
+            @offer = @client.offers(221598)
+          end
+        end
+
+        it "returns a response" do
+          expect(@offer).to_not be nil
+        end
+
+        it "returns an offer object" do
+          expect(@offer).to be_an_instance_of(Hash)
+          expect(@offer[:id]).to be_a(Integer).and be > 0
+          expect(@offer[:created_at]).to be_a(String)
+          expect(@offer[:version]).to be_a(Integer).and be > 0
+          expect(@offer[:status]).to be_a(String)
+        end
+      end
     end
   end
 end

--- a/spec/greenhouse_io/api/client_spec.rb
+++ b/spec/greenhouse_io/api/client_spec.rb
@@ -470,5 +470,27 @@ describe GreenhouseIo::Client do
         end
       end
     end
+
+    describe "#offers" do
+      context "given no id" do
+        before do
+          VCR.use_cassette('client/offers') do
+            @offers = @client.offers
+          end
+        end
+
+        it "returns a response" do
+          expect(@offers).to_not be nil
+        end
+
+        it "returns an array of offers" do
+          expect(@offers).to be_an_instance_of(Array)
+          expect(@offers.first[:id]).to be_a(Integer).and be > 0
+          expect(@offers.first[:created_at]).to be_a(String)
+          expect(@offers.first[:version]).to be_a(Integer).and be > 0
+          expect(@offers.first[:status]).to be_a(String)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Addresses #8 and adds tests for the new method for the 'All Offers' Harvest API endpoint.

Now you'll be able to get all offers for an organization:

```
gh.offers
```

Which evaluates to:

```ruby
[{
  :id=>221598,
  :version=>1,
  :application_id=>21708586,
  :created_at=>"2016-01-26T23:57:28Z",
  :sent_at=>nil,
  :resolved_at=>"2016-01-26T23:57:35Z",
  :starts_at=>"2016-01-26",
  :status=>"rejected",
  :custom_fields=>
   {:benefits=>"Full Medical",
    :bonus=>"1000",
    :current_salary=>"25000",
    :employment_type=>"Full-time",
    :notes=>"He was very excited.",
    :options=>"2000",
    :salary=>"31000",
    :source_cost=>nil,
    :visa_cost=>"200"
   }
 },
 {
  :id=>221603,
  ...
  },
]
```

Huge thanks to @wdewind for contributing this change!  :)