### PR TITLE
Allow job_id param to be used to find Applications

### DIFF
--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -3,7 +3,7 @@ module GreenhouseIo
     include HTTMultiParty
     include GreenhouseIo::API
 
-    PERMITTED_OPTIONS = [:page, :per_page]
+    PERMITTED_OPTIONS = [:page, :per_page, :job_id]
 
     attr_accessor :api_token, :rate_limit, :rate_limit_remaining
     base_uri 'https://harvest.greenhouse.io/v1'

--- a/spec/fixtures/cassettes/client/application_by_job_id.yml
+++ b/spec/fixtures/cassettes/client/application_by_job_id.yml
@@ -1,0 +1,139 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://123FakeToken:@harvest.greenhouse.io/v1/applications?job_id=144371
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 27 Jan 2016 18:09:18 GMT
+      Status:
+      - 200 OK
+      Content-Type:
+      - application/json;charset=utf-8
+      Link:
+      - <https://harvest.greenhouse.io/v1/applications?job_id=144371&page=1&per_page=100>;
+        rel="last"
+      Content-Length:
+      - '11280'
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Content-Type-Options:
+      - nosniff
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"id":21708448,"candidate_id":13381395,"prospect":false,"applied_at":"2015-11-19T20:22:30Z","rejected_at":null,"last_activity_at":"2015-11-19T20:22:30Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Foobar?","answer":null},{"question":"How
+        did you hear about this job?","answer":null},{"question":"Website","answer":null},{"question":"LinkedIn
+        Profile","answer":null}]},{"id":21708450,"candidate_id":13381397,"prospect":false,"applied_at":"2015-11-19T20:22:30Z","rejected_at":null,"last_activity_at":"2015-11-19T20:22:30Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Foobar?","answer":null},{"question":"How
+        did you hear about this job?","answer":null},{"question":"Website","answer":null},{"question":"LinkedIn
+        Profile","answer":null}]},{"id":21708449,"candidate_id":13381396,"prospect":false,"applied_at":"2015-11-19T20:22:30Z","rejected_at":null,"last_activity_at":"2015-11-19T20:22:30Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Foobar?","answer":null},{"question":"How
+        did you hear about this job?","answer":null},{"question":"Website","answer":null},{"question":"LinkedIn
+        Profile","answer":null}]},{"id":21708451,"candidate_id":13381398,"prospect":false,"applied_at":"2015-11-19T20:22:30Z","rejected_at":null,"last_activity_at":"2015-11-19T20:22:30Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Foobar?","answer":null},{"question":"How
+        did you hear about this job?","answer":null},{"question":"Website","answer":null},{"question":"LinkedIn
+        Profile","answer":null}]},{"id":21708452,"candidate_id":13381399,"prospect":false,"applied_at":"2015-11-19T20:22:31Z","rejected_at":null,"last_activity_at":"2015-11-19T20:22:31Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Foobar?","answer":null},{"question":"How
+        did you hear about this job?","answer":null},{"question":"Website","answer":null},{"question":"LinkedIn
+        Profile","answer":null}]},{"id":21708453,"candidate_id":13381400,"prospect":false,"applied_at":"2015-11-19T20:22:31Z","rejected_at":null,"last_activity_at":"2015-11-19T20:22:31Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Foobar?","answer":null},{"question":"How
+        did you hear about this job?","answer":null},{"question":"Website","answer":null},{"question":"LinkedIn
+        Profile","answer":null}]},{"id":21708454,"candidate_id":13381401,"prospect":false,"applied_at":"2015-11-19T20:22:31Z","rejected_at":null,"last_activity_at":"2015-11-19T20:22:31Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Foobar?","answer":null},{"question":"How
+        did you hear about this job?","answer":null},{"question":"Website","answer":null},{"question":"LinkedIn
+        Profile","answer":null}]},{"id":21708456,"candidate_id":13381403,"prospect":false,"applied_at":"2015-11-19T20:22:32Z","rejected_at":null,"last_activity_at":"2015-11-19T20:22:32Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Foobar?","answer":null},{"question":"How
+        did you hear about this job?","answer":null},{"question":"Website","answer":null},{"question":"LinkedIn
+        Profile","answer":null}]},{"id":21708460,"candidate_id":13381407,"prospect":false,"applied_at":"2015-11-19T20:22:35Z","rejected_at":null,"last_activity_at":"2015-11-19T20:22:35Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Foobar?","answer":null},{"question":"How
+        did you hear about this job?","answer":null},{"question":"Website","answer":null},{"question":"LinkedIn
+        Profile","answer":null}]},{"id":21708585,"candidate_id":13381528,"prospect":false,"applied_at":"2015-11-19T20:26:25Z","rejected_at":null,"last_activity_at":"2015-11-19T20:26:25Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Foobar?","answer":null},{"question":"How
+        did you hear about this job?","answer":null},{"question":"Website","answer":null},{"question":"LinkedIn
+        Profile","answer":null}]},{"id":21708586,"candidate_id":13381530,"prospect":false,"applied_at":"2015-11-19T20:26:25Z","rejected_at":"2016-01-26T23:57:35Z","last_activity_at":"2016-01-26T23:57:35Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":{"id":14,"name":"None
+        specified","type":{"id":3,"name":"None specified"}},"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"rejected","current_stage":{"id":1031644,"name":"Offer"},"answers":[{"question":"Foobar?","answer":null},{"question":"How
+        did you hear about this job?","answer":null},{"question":"Website","answer":null},{"question":"LinkedIn
+        Profile","answer":null}]},{"id":21708588,"candidate_id":13381531,"prospect":false,"applied_at":"2015-11-19T20:26:26Z","rejected_at":null,"last_activity_at":"2015-11-19T20:26:26Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Foobar?","answer":null},{"question":"How
+        did you hear about this job?","answer":null},{"question":"Website","answer":null},{"question":"LinkedIn
+        Profile","answer":null}]},{"id":21769983,"candidate_id":13440415,"prospect":false,"applied_at":"2015-11-20T22:25:49Z","rejected_at":null,"last_activity_at":"2015-11-20T22:25:49Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Yeah?","answer":"Five"},{"question":"Huh?","answer":"Yes"},{"question":"What?","answer":"wfawfe"},{"question":"Foobar?","answer":"sgerag"},{"question":"How
+        did you hear about this job?","answer":"fawefaewttag"},{"question":"Website","answer":"afwaefw"},{"question":"LinkedIn
+        Profile","answer":"wafawefaw"}]},{"id":21772362,"candidate_id":13442759,"prospect":false,"applied_at":"2015-11-20T22:33:14Z","rejected_at":null,"last_activity_at":"2015-11-20T22:33:14Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Yeah?","answer":"Five"},{"question":"Huh?","answer":"Yes"},{"question":"What?","answer":"wfawfe"},{"question":"Foobar?","answer":"sgerag"},{"question":"How
+        did you hear about this job?","answer":"fawefaewttag"},{"question":"Website","answer":"afwaefw"},{"question":"LinkedIn
+        Profile","answer":"wafawefaw"}]},{"id":21772559,"candidate_id":13442958,"prospect":false,"applied_at":"2015-11-20T22:33:45Z","rejected_at":null,"last_activity_at":"2015-11-20T22:33:45Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Yeah?","answer":"Five"},{"question":"Huh?","answer":"Yes"},{"question":"What?","answer":"wfawfe"},{"question":"Foobar?","answer":"sgerag"},{"question":"How
+        did you hear about this job?","answer":"fawefaewttag"},{"question":"Website","answer":"afwaefw"},{"question":"LinkedIn
+        Profile","answer":"wafawefaw"}]},{"id":21772681,"candidate_id":13443080,"prospect":false,"applied_at":"2015-11-20T22:34:04Z","rejected_at":null,"last_activity_at":"2015-11-20T22:34:03Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[{"question":"Yeah?","answer":"Five"},{"question":"Huh?","answer":"Yes"},{"question":"What?","answer":"wfawfe"},{"question":"Foobar?","answer":"sgerag"},{"question":"How
+        did you hear about this job?","answer":"fawefaewttag"},{"question":"Website","answer":"afwaefw"},{"question":"LinkedIn
+        Profile","answer":"wafawefaw"}]},{"id":21880506,"candidate_id":13549465,"prospect":false,"applied_at":"2015-11-23T19:58:34Z","rejected_at":null,"last_activity_at":"2016-01-26T23:59:27Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":null,"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"active","current_stage":{"id":1031644,"name":"Offer"},"answers":[{"question":"Yeah?","answer":"Three"},{"question":"Huh?","answer":"No"},{"question":"What?","answer":null},{"question":"Foobar?","answer":null},{"question":"How
+        did you hear about this job?","answer":null},{"question":"Website","answer":null},{"question":"LinkedIn
+        Profile","answer":null}]},{"id":22109641,"candidate_id":13769762,"prospect":false,"applied_at":"2015-11-30T22:30:47Z","rejected_at":"2015-11-30T22:30:52Z","last_activity_at":"2015-11-30T22:30:53Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":{"id":158108,"name":"Gordon Zheng"},"rejection_reason":{"id":14,"name":"None
+        specified","type":{"id":3,"name":"None specified"}},"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"rejected","current_stage":{"id":1031639,"name":"Application
+        Review"},"answers":[]},{"id":24709881,"candidate_id":13769693,"prospect":false,"applied_at":"2016-01-26T23:58:09Z","rejected_at":null,"last_activity_at":"2016-01-26T23:59:07Z","source":{"id":2,"public_name":"Jobs
+        page on your website"},"credited_to":{"id":158108,"name":"Gordon Zheng"},"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
+        Cop"}],"status":"hired","current_stage":null,"answers":[]}]'
+    http_version: 
+  recorded_at: Wed, 27 Jan 2016 18:09:18 GMT
+recorded_with: VCR 3.0.1

--- a/spec/greenhouse_io/api/client_spec.rb
+++ b/spec/greenhouse_io/api/client_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe GreenhouseIo::Client do
 
+  FAKE_API_TOKEN = '123FakeToken'
+
   it "should have a base url for an API endpoint" do
     expect(GreenhouseIo::Client.base_uri).to eq("https://harvest.greenhouse.io/v1")
   end
@@ -10,12 +12,12 @@ describe GreenhouseIo::Client do
 
     before do
       GreenhouseIo.configuration.symbolize_keys = true
-      @client = GreenhouseIo::Client.new('123FakeToken')
+      @client = GreenhouseIo::Client.new(FAKE_API_TOKEN)
     end
 
     describe "#initialize" do
       it "has an api_token" do
-        expect(@client.api_token).to eq('123FakeToken')
+        expect(@client.api_token).to eq(FAKE_API_TOKEN)
       end
 
       it "uses the configuration value when token is not specified" do

--- a/spec/greenhouse_io/api/client_spec.rb
+++ b/spec/greenhouse_io/api/client_spec.rb
@@ -263,6 +263,24 @@ describe GreenhouseIo::Client do
           expect(@application).to have_key(:person_id)
         end
       end
+
+      context "given a job_id" do
+        before do
+          VCR.use_cassette('client/application_by_job_id') do
+            @applications = @client.applications(nil, :job_id => 144371)
+          end
+        end
+
+        it "returns a response" do
+          expect(@applications).to_not be_nil
+        end
+
+        it "returns an array of applications" do
+          expect(@applications).to be_an_instance_of(Array)
+          expect(@applications.first).to be_an_instance_of(Hash)
+          expect(@applications.first).to have_key(:prospect)
+        end
+      end
     end
 
     describe "#scorecards" do


### PR DESCRIPTION
This change allows you to list Applications that belong to a given `job_id` like so:

```ruby
gh.applications(nil, :job_id => 144371) 
#=> [{:id=>21708448, :candidate_id=>13381395, :prospect=>false ...
```

Shout out to @rodrigomaia17 for contributing this code! (via #5)