### PR TITLE
Add all_scorecards method

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Methods in which an `id` is optional:
 * `jobs`
 * `users`
 * `sources`
+* `all_scorecards`
 * `offers`
 
 Methods in which an `id` is **required**:

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -40,6 +40,10 @@ module GreenhouseIo
       get_from_harvest_api "/applications/#{id}/scorecards", options
     end
 
+    def all_scorecards(id = nil, options = {})
+      get_from_harvest_api "/scorecards/#{id}", options
+    end
+
     def scheduled_interviews(id, options = {})
       get_from_harvest_api "/applications/#{id}/scheduled_interviews", options
     end

--- a/lib/greenhouse_io/version.rb
+++ b/lib/greenhouse_io/version.rb
@@ -1,3 +1,3 @@
 module GreenhouseIo
-  VERSION = "2.2.0"
+  VERSION = "2.3.0"
 end

--- a/spec/fixtures/cassettes/client/all_scorecards.yml
+++ b/spec/fixtures/cassettes/client/all_scorecards.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://123FakeToken:@harvest.greenhouse.io/v1/scorecards/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 10 Feb 2016 03:17:48 GMT
+      Status:
+      - 200 OK
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '370562'
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Content-Type-Options:
+      - nosniff
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '[{"id":123,"interview":"Preliminary Screening Call","candidate_id":123,"interviewed_at":"2015-10-08T19:00:00.000Z","submitted_by":{"id":123,"name":"Test User"},"submitted_at":"2015-10-08T19:11:09.287Z","overall_recommendation":"yes","ratings":{"definitely_not":[],"no":[],"mixed":[],"yes":[],"strong_yes":[]},"questions":[{"id":null,"question":"Key Take-Aways","answer":""},{"id":null,"question":"Private Notes","answer":""}]},{"id":456,"interview":"Application Review","candidate_id":456,"interviewed_at":"2015-10-08T19:00:00.000Z","submitted_by":{"id":456,"name":"Test User"},"submitted_at":"2015-10-08T19:11:09.287Z","overall_recommendation":"yes","ratings":{"definitely_not":[],"no":[],"mixed":[],"yes":[],"strong_yes":[]},"questions":[{"id":null,"question":"Key Take-Aways","answer":""},{"id":null,"question":"Private Notes","answer":""}]}]'
+    http_version:
+  recorded_at: Wed, 10 Feb 2016 03:17:48 GMT
+recorded_with: VCR 3.0.1

--- a/spec/greenhouse_io/api/client_spec.rb
+++ b/spec/greenhouse_io/api/client_spec.rb
@@ -305,6 +305,26 @@ describe GreenhouseIo::Client do
       end
     end
 
+    describe "#all_scorecards" do
+      before do
+        VCR.use_cassette('client/all_scorecards') do
+          @scorecard = @client.all_scorecards
+        end
+      end
+
+      it "returns a response" do
+        expect(@scorecard).to_not be_nil
+      end
+
+      it "returns an array of scorecards" do
+        expect(@scorecard).to be_an_instance_of(Array)
+      end
+
+      it "returns details of the scorecards" do
+        expect(@scorecard.first).to have_key(:interview)
+      end
+    end
+
     describe "#scheduled_interviews" do
       before do
         VCR.use_cassette('client/scheduled_interviews') do


### PR DESCRIPTION
Adding a method for the `all_scorecards` api endpoint, along with some tests cribbed from the `scorecards` endpoint. We're already using this for some scripts internally and I figured it belongs in the core gem, too.