### PR TITLE
Make link header available to the client.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ rdoc
 spec/reports
 tmp
 .ruby-*
+*.swp
+*.un~
+tags

--- a/greenhouse_io.gemspec
+++ b/greenhouse_io.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency('httmultiparty', '~> 0.3.16')
-  spec.add_dependency('multi_json', '~>1.11.2')
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/lib/greenhouse_io.rb
+++ b/lib/greenhouse_io.rb
@@ -1,5 +1,5 @@
 require 'httmultiparty'
-require 'multi_json'
+require 'json'
 require 'cgi'
 
 require "greenhouse_io/version"

--- a/lib/greenhouse_io/api.rb
+++ b/lib/greenhouse_io/api.rb
@@ -9,7 +9,7 @@ module GreenhouseIo
     end
 
     def parse_json(response)
-      MultiJson.load(response.body, symbolize_keys: GreenhouseIo.configuration.symbolize_keys)
+      JSON.parse(response.body, symbolize_names: GreenhouseIo.configuration.symbolize_keys)
     end
 
     def basic_auth

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -5,7 +5,7 @@ module GreenhouseIo
 
     PERMITTED_OPTIONS = [:page, :per_page, :job_id]
 
-    attr_accessor :api_token, :rate_limit, :rate_limit_remaining
+    attr_accessor :api_token, :rate_limit, :rate_limit_remaining, :link
     base_uri 'https://harvest.greenhouse.io/v1'
 
     def initialize(api_token = nil)
@@ -80,7 +80,7 @@ module GreenhouseIo
 
     def get_from_harvest_api(url, options = {})
       response = get_response(url, query: permitted_options(options), basic_auth: basic_auth)
-      set_rate_limits(response.headers)
+      set_headers_info(response.headers)
       if response.code == 200
         parse_json(response)
       else
@@ -88,9 +88,10 @@ module GreenhouseIo
       end
     end
 
-    def set_rate_limits(headers)
+    def set_headers_info(headers)
       self.rate_limit = headers['x-ratelimit-limit'].to_i
       self.rate_limit_remaining = headers['x-ratelimit-remaining'].to_i
+      self.link = headers['link'].to_s
     end
   end
 end

--- a/spec/greenhouse_io/api/client_spec.rb
+++ b/spec/greenhouse_io/api/client_spec.rb
@@ -43,22 +43,28 @@ describe GreenhouseIo::Client do
       end
     end
 
-    describe "#set_rate_limits" do
+    describe "#set_headers_info" do
       before do
         @headers = {
           'x-ratelimit-limit' => '20',
-          'x-ratelimit-remaining' => '20'
+          'x-ratelimit-remaining' => '20',
+          'link' => '<https://harvest.greenhouse.io/v1/candidates?page=2&per_page=100>; rel="next",<https://harvest.greenhouse.io/v1/candidates?page=142&per_page=100>; rel="last"'
         }
       end
 
       it "sets the rate limit" do
-        @client.send(:set_rate_limits, @headers)
+        @client.send(:set_headers_info, @headers)
         expect(@client.rate_limit).to eq(20)
       end
 
       it "sets the remaining rate limit" do
-        @client.send(:set_rate_limits, @headers)
+        @client.send(:set_headers_info, @headers)
         expect(@client.rate_limit_remaining).to eq(20)
+      end
+
+      it "sets rest link" do
+        @client.send(:set_headers_info, @headers)
+        expect(@client.link).to match(/rel="last"/)
       end
     end
 


### PR DESCRIPTION
Remove MultiJson dependecy. Ruby includes Json gem.
Change client to make available link header.
Add vi swp and temp files to .gitignore.