### PR TITLE
add support for creating notes using Harvest API

### DIFF
--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -32,6 +32,10 @@ module GreenhouseIo
       get_from_harvest_api "/candidates/#{id}/activity_feed", options
     end
 
+    def create_note(id, note_hash, on_behalf_of)
+      post_to_harvest_api("/candidates/#{id}/activity_feed/notes", note_hash, on_behalf_of)
+    end
+
     def applications(id = nil, options = {})
       get_from_harvest_api "/applications#{path_id(id)}", options
     end
@@ -80,6 +84,17 @@ module GreenhouseIo
 
     def get_from_harvest_api(url, options = {})
       response = get_response(url, query: permitted_options(options), basic_auth: basic_auth)
+      set_rate_limits(response.headers)
+      if response.code == 200
+        parse_json(response)
+      else
+        raise GreenhouseIo::Error.new(response.code)
+      end
+    end
+
+    def post_to_harvest_api(url, body, on_behalf_of)
+      options = { :body => body.to_json, :basic_auth => basic_auth, :headers => {"On-Behalf-Of" => on_behalf_of.to_s} }
+      response = post_response(url, options)
       set_rate_limits(response.headers)
       if response.code == 200
         parse_json(response)

--- a/spec/fixtures/cassettes/client/create_note.yml
+++ b/spec/fixtures/cassettes/client/create_note.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates/1/activity_feed/notes
+    body:
+      encoding: UTF-8
+      string: '{"user_id":2,"message":"Candidate on vacation","visibility":"public"}'
+    headers:
+      On-Behalf-Of:
+      - '2'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - close
+      Date:
+      - Mon, 18 Apr 2016 19:41:43 GMT
+      Status:
+      - 200 OK
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '154'
+      X-Ratelimit-Limit:
+      - '40'
+      X-Ratelimit-Remaining:
+      - '39'
+      X-Content-Type-Options:
+      - nosniff
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"created_at":"2016-04-18T19:43:52.534Z","body":"Candidate on vacation","user":{"id":2,"name":"Richard Feynman"},"private":false,"visiblity":"public"}'
+    http_version: 
+  recorded_at: Mon, 18 Apr 2016 19:41:44 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/create_note_invalid_candidate_id.yml
+++ b/spec/fixtures/cassettes/client/create_note_invalid_candidate_id.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates/99/activity_feed/notes
+    body:
+      encoding: UTF-8
+      string: '{"user_id":2,"message":"Candidate on vacation","visibility":"public"}'
+    headers:
+      On-Behalf-Of:
+      - '2'
+  response:
+    status:
+      code: 404
+      message: Resource not found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - close
+      Date:
+      - Mon, 18 Apr 2016 19:41:43 GMT
+      Status:
+      - 200 OK
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '32'
+      X-Ratelimit-Limit:
+      - '40'
+      X-Ratelimit-Remaining:
+      - '39'
+      X-Content-Type-Options:
+      - nosniff
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"message":"Resource not found"}'
+    http_version: 
+  recorded_at: Mon, 18 Apr 2016 19:41:44 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/create_note_invalid_missing_field.yml
+++ b/spec/fixtures/cassettes/client/create_note_invalid_missing_field.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates/1/activity_feed/notes
+    body:
+      encoding: UTF-8
+      string: '{"user_id":2,"visibility":"public"}'
+    headers:
+      On-Behalf-Of:
+      - '2'
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - close
+      Date:
+      - Mon, 18 Apr 2016 19:41:43 GMT
+      Status:
+      - 200 OK
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '70'
+      X-Ratelimit-Limit:
+      - '40'
+      X-Ratelimit-Remaining:
+      - '39'
+      X-Content-Type-Options:
+      - nosniff
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"message":"Missing required field: body","field":"body"}]}'
+    http_version: 
+  recorded_at: Mon, 18 Apr 2016 19:41:44 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/create_note_invalid_on_behalf_of.yml
+++ b/spec/fixtures/cassettes/client/create_note_invalid_on_behalf_of.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates/1/activity_feed/notes
+    body:
+      encoding: UTF-8
+      string: '{"user_id":2,"message":"Candidate on vacation","visibility":"public"}'
+    headers:
+      On-Behalf-Of:
+      - '99'
+  response:
+    status:
+      code: 404
+      message: Resource not found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - close
+      Date:
+      - Mon, 18 Apr 2016 19:41:43 GMT
+      Status:
+      - 200 OK
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '32'
+      X-Ratelimit-Limit:
+      - '40'
+      X-Ratelimit-Remaining:
+      - '39'
+      X-Content-Type-Options:
+      - nosniff
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"message":"Resource not found"}'
+    http_version: 
+  recorded_at: Mon, 18 Apr 2016 19:41:44 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/create_note_invalid_user_id.yml
+++ b/spec/fixtures/cassettes/client/create_note_invalid_user_id.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates/1/activity_feed/notes
+    body:
+      encoding: UTF-8
+      string: '{"user_id":99,"message":"Candidate on vacation","visibility":"public"}'
+    headers:
+      On-Behalf-Of:
+      - '2'
+  response:
+    status:
+      code: 404
+      message: Resource not found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - close
+      Date:
+      - Mon, 18 Apr 2016 19:41:43 GMT
+      Status:
+      - 200 OK
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '32'
+      X-Ratelimit-Limit:
+      - '40'
+      X-Ratelimit-Remaining:
+      - '39'
+      X-Content-Type-Options:
+      - nosniff
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"message":"Resource not found"}'
+    http_version: 
+  recorded_at: Mon, 18 Apr 2016 19:41:44 GMT
+recorded_with: VCR 3.0.1

--- a/spec/greenhouse_io/api/client_spec.rb
+++ b/spec/greenhouse_io/api/client_spec.rb
@@ -225,6 +225,87 @@ describe GreenhouseIo::Client do
       end
     end
 
+    describe "#create_note" do
+      it "posts an note for a specified candidate" do
+        VCR.use_cassette('client/create_note') do
+          create_note = @client.create_note(
+            1,
+            {
+                user_id: 2,
+                message: "Candidate on vacation",
+                visibility: "public"
+            },
+            2
+          )
+          expect(create_note).to_not be_nil
+          expect(create_note).to include :body => 'Candidate on vacation'
+        end
+      end
+
+      it "errors when given invalid On-Behalf-Of id" do
+        VCR.use_cassette('client/create_note_invalid_on_behalf_of') do
+          expect {
+            @client.create_note(
+              1,
+              {
+                  user_id: 2,
+                  message: "Candidate on vacation",
+                  visibility: "public"
+              },
+              99
+            )
+          }.to raise_error(GreenhouseIo::Error)
+        end
+      end
+
+      it "errors when given an invalid candidate id" do
+        VCR.use_cassette('client/create_note_invalid_candidate_id') do
+          expect {
+            @client.create_note(
+              99,
+              {
+                  user_id: 2,
+                  message: "Candidate on vacation",
+                  visibility: "public"
+              },
+              2
+            )
+          }.to raise_error(GreenhouseIo::Error)
+        end
+      end
+
+      it "errors when given an invalid user_id" do
+        VCR.use_cassette('client/create_note_invalid_user_id') do
+          expect {
+            @client.create_note(
+              1,
+              {
+                  user_id: 99,
+                  message: "Candidate on vacation",
+                  visibility: "public"
+              },
+              2
+            )
+          }.to raise_error(GreenhouseIo::Error)
+        end
+      end
+
+      it "errors when missing required field" do
+        VCR.use_cassette('client/create_note_invalid_missing_field') do
+          expect {
+            @client.create_note(
+              1,
+              {
+                  user_id: 2,
+                  visibility: "public"
+              },
+              2
+            )
+          }.to raise_error(GreenhouseIo::Error)
+        end
+      end
+    end
+
     describe "#applications" do
       context "given no id" do
         before do


### PR DESCRIPTION
Usage:

```
client.create_note( candidate_id,
                    { user_id: user_id, body: "my message", visibility: "public" },
                    on_behalf_of )
```