### PR TITLE
Expose link header in GreenhouseIo::Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ rdoc
 spec/reports
 tmp
 .ruby-*
+*.swp
+*.un~
+tags

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,17 @@
 
 This project follows [semantic versioning](http://semver.org/).  This changelog follows suggestions from [keepachangelog.com](http://keepachangelog.com/).
 
-## Version 2.3.1
+## Version 2.4.0
 Released 2016-04-20.
+
+#### Added
+- Exposed `link` HTTP header in `GreenhouseIo::Client`.
+
+#### Removed
+- Removed dependency on `multi_json` in favor of Ruby's `json` module.
+
+## Version 2.3.1
+Released 2016-04-20.  In retrospect, this should've been a minor version bump instead of a minor version since this added functionality, not a bug fix.
 
 #### Added
 - Added method `create_candidate_note`.  Thanks for contributing, [@jleven](https://github.com/jleven)!

--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ gh_client = GreenhouseIo::Client.new
 
 #### Listing candidates
 
-```
+```ruby
 gh_client.candidates
 ```
 
 #### Creating a candidate note
 Use this method to attach a new note to a candidate.
 
-```
+```ruby
 candidate_id = 4567
 author_id = 123 # ID of the user who wrote this note
 note = {
@@ -153,6 +153,16 @@ All `GreenhouseIo::Client` API methods accept `:page` and `:per_page` options to
 ```ruby
 gh_client.offices(id, page: 1, per_page: 2)
 ```
+
+You can determine the last page and next page by looking at the `link` header from the last response:
+
+```ruby
+gh_client.link
+
+# => '<https://harvest.greenhouse.io/v1/candidates?page=2&per_page=100>; rel="next",<https://harvest.greenhouse.io/v1/candidates?page=142&per_page=100>; rel="last"'
+```
+
+You'll need to manually parse the `next` and `last` links to tell what the next or final page number will be.
 
 #### Available methods
 

--- a/greenhouse_io.gemspec
+++ b/greenhouse_io.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency('httmultiparty', '~> 0.3.16')
-  spec.add_dependency('multi_json', '~>1.11.2')
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/lib/greenhouse_io.rb
+++ b/lib/greenhouse_io.rb
@@ -1,5 +1,4 @@
 require 'httmultiparty'
-require 'multi_json'
 require 'json'
 
 require "greenhouse_io/version"

--- a/lib/greenhouse_io/api.rb
+++ b/lib/greenhouse_io/api.rb
@@ -9,7 +9,7 @@ module GreenhouseIo
     end
 
     def parse_json(response)
-      MultiJson.load(response.body, symbolize_keys: GreenhouseIo.configuration.symbolize_keys)
+      JSON.parse(response.body, symbolize_names: GreenhouseIo.configuration.symbolize_keys)
     end
 
     def basic_auth

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -5,7 +5,7 @@ module GreenhouseIo
 
     PERMITTED_OPTIONS = [:page, :per_page, :job_id]
 
-    attr_accessor :api_token, :rate_limit, :rate_limit_remaining
+    attr_accessor :api_token, :rate_limit, :rate_limit_remaining, :link
     base_uri 'https://harvest.greenhouse.io/v1'
 
     def initialize(api_token = nil)
@@ -92,7 +92,7 @@ module GreenhouseIo
         :basic_auth => basic_auth
       })
 
-      set_rate_limits(response.headers)
+      set_headers_info(response.headers)
 
       if response.code == 200
         parse_json(response)
@@ -108,7 +108,7 @@ module GreenhouseIo
         :headers => headers
       })
 
-      set_rate_limits(response.headers)
+      set_headers_info(response.headers)
 
       if response.code == 200
         parse_json(response)
@@ -117,9 +117,10 @@ module GreenhouseIo
       end
     end
 
-    def set_rate_limits(headers)
+    def set_headers_info(headers)
       self.rate_limit = headers['x-ratelimit-limit'].to_i
       self.rate_limit_remaining = headers['x-ratelimit-remaining'].to_i
+      self.link = headers['link'].to_s
     end
   end
 end

--- a/lib/greenhouse_io/version.rb
+++ b/lib/greenhouse_io/version.rb
@@ -1,3 +1,3 @@
 module GreenhouseIo
-  VERSION = "2.3.1"
+  VERSION = "2.4.0"
 end

--- a/spec/fixtures/cassettes/client/headers.yml
+++ b/spec/fixtures/cassettes/client/headers.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 23 Apr 2014 23:23:01 GMT
+      Link:
+      - "<https://harvest.greenhouse.io/v1/candidates/?page=1&per_page=100>; rel=\"last\""
+      Status:
+      - 200 OK
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '20'
+      X-Ratelimit-Remaining:
+      - '19'
+      Content-Length:
+      - '68109'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: "[{\"id\":1,\"first_name\":\"User\",\"last_name\":\"One\",\"company\":null,\"title\":null,\"created_at\":\"2013-10-17T15:32:26Z\",\"last_activity\":\"2013-10-30T14:37:10Z\",\"photo_url\":null,\"attachments\":[{\"filename\":\"USER_1_Resume_10.13.pdf\",\"url\":\"https://resumes.com/USER_1_Resume_10.13.pdf\",\"type\":\"cover_letter\"},{\"filename\":\"USER_1_Resume_10.13.pdf\",\"url\":\"https://prod-heroku.s3.amazonaws.com/person_attachments/USER_1_Resume_10.13.pdf\",\"type\":\"resume\"}],\"application_ids\":[1234],\"phone_numbers\":[{\"value\":\"123-345-5678\",\"type\":\"other\"}],\"addresses\":[],\"email_addresses\":[{\"value\":\"user_one@email.com\",\"type\":\"personal\"}],\"website_addresses\":[],\"social_media_addresses\":[]}]"
+    http_version: 
+  recorded_at: Wed, 23 Apr 2014 23:23:02 GMT
+recorded_with: VCR 2.5.0

--- a/spec/greenhouse_io/api/client_spec.rb
+++ b/spec/greenhouse_io/api/client_spec.rb
@@ -43,22 +43,28 @@ describe GreenhouseIo::Client do
       end
     end
 
-    describe "#set_rate_limits" do
+    describe "#set_headers_info" do
       before do
         @headers = {
           'x-ratelimit-limit' => '20',
-          'x-ratelimit-remaining' => '20'
+          'x-ratelimit-remaining' => '20',
+          'link' => '<https://harvest.greenhouse.io/v1/candidates?page=2&per_page=100>; rel="next",<https://harvest.greenhouse.io/v1/candidates?page=142&per_page=100>; rel="last"'
         }
       end
 
       it "sets the rate limit" do
-        @client.send(:set_rate_limits, @headers)
+        @client.send(:set_headers_info, @headers)
         expect(@client.rate_limit).to eq(20)
       end
 
       it "sets the remaining rate limit" do
-        @client.send(:set_rate_limits, @headers)
+        @client.send(:set_headers_info, @headers)
         expect(@client.rate_limit_remaining).to eq(20)
+      end
+
+      it "sets rest link" do
+        @client.send(:set_headers_info, @headers)
+        expect(@client.link).to match(/rel="last"/)
       end
     end
 

--- a/spec/greenhouse_io/api/client_spec.rb
+++ b/spec/greenhouse_io/api/client_spec.rb
@@ -45,26 +45,21 @@ describe GreenhouseIo::Client do
 
     describe "#set_headers_info" do
       before do
-        @headers = {
-          'x-ratelimit-limit' => '20',
-          'x-ratelimit-remaining' => '20',
-          'link' => '<https://harvest.greenhouse.io/v1/candidates?page=2&per_page=100>; rel="next",<https://harvest.greenhouse.io/v1/candidates?page=142&per_page=100>; rel="last"'
-        }
+        VCR.use_cassette('client/headers') do
+          @client.candidates
+        end
       end
 
       it "sets the rate limit" do
-        @client.send(:set_headers_info, @headers)
         expect(@client.rate_limit).to eq(20)
       end
 
       it "sets the remaining rate limit" do
-        @client.send(:set_headers_info, @headers)
-        expect(@client.rate_limit_remaining).to eq(20)
+        expect(@client.rate_limit_remaining).to eq(19)
       end
 
       it "sets rest link" do
-        @client.send(:set_headers_info, @headers)
-        expect(@client.link).to match(/rel="last"/)
+        expect(@client.link).to eq('<https://harvest.greenhouse.io/v1/candidates/?page=1&per_page=100>; rel="last"')
       end
     end
 


### PR DESCRIPTION
Merges in #17.

Exposing the `Link` header is the first step toward improving pagination information.  Next, let's think about parsing out the final page number and representing that neatly.