### PR TITLE
Implement #update_application

### DIFF
--- a/lib/greenhouse_io/api.rb
+++ b/lib/greenhouse_io/api.rb
@@ -8,6 +8,10 @@ module GreenhouseIo
       self.class.post(url, options)
     end
 
+    def patch_response(url, options)
+      self.class.patch(url, options)
+    end
+
     def parse_json(response)
       JSON.parse(response.body, symbolize_names: GreenhouseIo.configuration.symbolize_keys)
     end

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -44,6 +44,14 @@ module GreenhouseIo
       get_from_harvest_api "/applications#{path_id(id)}", options
     end
 
+    def update_application(id, options, on_behalf_of)
+      patch_to_harvest_api(
+        "/applications/#{id}",
+        options,
+        { 'On-Behalf-Of' => on_behalf_of.to_s }
+      )
+    end
+
     def offers_for_application(id, options = {})
       get_from_harvest_api "/applications/#{id}/offers", options
     end
@@ -96,7 +104,7 @@ module GreenhouseIo
 
     def get_from_harvest_api(url, options = {})
       response = get_response(url, {
-        :query => permitted_options(options), 
+        :query => permitted_options(options),
         :basic_auth => basic_auth
       })
 
@@ -111,6 +119,22 @@ module GreenhouseIo
 
     def post_to_harvest_api(url, body, headers)
       response = post_response(url, {
+        :body => JSON.dump(body),
+        :basic_auth => basic_auth,
+        :headers => headers
+      })
+
+      set_headers_info(response.headers)
+
+      if response.code == 200
+        parse_json(response)
+      else
+        raise GreenhouseIo::Error.new(response.code)
+      end
+    end
+
+    def patch_to_harvest_api(url, body, headers)
+      response = patch_response(url, {
         :body => JSON.dump(body),
         :basic_auth => basic_auth,
         :headers => headers

--- a/spec/fixtures/cassettes/client/update_application.yml
+++ b/spec/fixtures/cassettes/client/update_application.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://123FakeToken:@harvest.greenhouse.io/v1/applications/64087658
+    body:
+      encoding: UTF-8
+      string: '{"source_id":130370}'
+    headers:
+      On-Behalf-Of:
+      - '509925'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Mon, 31 Jul 2017 11:42:38 GMT
+      Server:
+      - nginx
+      Status:
+      - 200 OK
+      X-Content-Type-Options:
+      - nosniff
+      X-Gh-Proxy:
+      - 'true'
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      Content-Length:
+      - '505'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"id":64087658,"candidate_id":52865001,"prospect":false,"applied_at":"2017-07-31T10:36:03.316Z","rejected_at":null,"last_activity_at":"2017-07-31T10:59:50.698Z","source":{"id":130370,"public_name":"Honeypot"},"credited_to":null,"rejection_reason":null,"rejection_details":null,"jobs":[{"id":474298,"name":"Data
+        Engineer (f/m) "}],"status":"active","current_stage":{"id":3458762,"name":"Application
+        Review"},"answers":[],"prospect_detail":{"prospect_pool":null,"prospect_stage":null,"prospect_owner":null}}'
+    http_version:
+  recorded_at: Mon, 31 Jul 2017 11:42:39 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/client/update_application_invalid_candidate_id.yml
+++ b/spec/fixtures/cassettes/client/update_application_invalid_candidate_id.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://123FakeToken:@harvest.greenhouse.io/v1/applications/1010101
+    body:
+      encoding: UTF-8
+      string: '{"source_id":130370}'
+    headers:
+      On-Behalf-Of:
+      - '509925'
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Mon, 31 Jul 2017 11:45:59 GMT
+      Server:
+      - nginx
+      Status:
+      - 403 Forbidden
+      X-Content-Type-Options:
+      - nosniff
+      X-Gh-Proxy:
+      - 'true'
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '48'
+      Content-Length:
+      - '51'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"You do not have access to that record"}'
+    http_version:
+  recorded_at: Mon, 31 Jul 2017 11:45:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/client/update_application_invalid_on_behalf_of.yml
+++ b/spec/fixtures/cassettes/client/update_application_invalid_on_behalf_of.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://123FakeToken:@harvest.greenhouse.io/v1/applications/64087658
+    body:
+      encoding: UTF-8
+      string: '{"source_id":130370}'
+    headers:
+      On-Behalf-Of:
+      - '101010'
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Mon, 31 Jul 2017 11:45:58 GMT
+      Server:
+      - nginx
+      Status:
+      - 403 Forbidden
+      X-Content-Type-Options:
+      - nosniff
+      X-Gh-Proxy:
+      - 'true'
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      Content-Length:
+      - '51'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"You do not have access to that record"}'
+    http_version:
+  recorded_at: Mon, 31 Jul 2017 11:45:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/greenhouse_io/api/client_spec.rb
+++ b/spec/greenhouse_io/api/client_spec.rb
@@ -367,6 +367,50 @@ describe GreenhouseIo::Client do
       end
     end
 
+    describe "#update_application" do
+      it "update the specified application" do
+        VCR.use_cassette('client/update_application') do
+          update_application = @client.update_application(
+            64087658,
+            {
+                source_id: 130370
+            },
+            509925
+          )
+          expect(update_application).to_not be_nil
+          expect(update_application[:source][:id]).to eq 130370
+        end
+      end
+
+      it "errors when given invalid On-Behalf-Of id" do
+        VCR.use_cassette('client/update_application_invalid_on_behalf_of') do
+          expect {
+            @client.update_application(
+              64087658,
+              {
+                  source_id: 130370
+              },
+              101010
+            )
+          }.to raise_error(GreenhouseIo::Error)
+        end
+      end
+
+      it "errors when given an invalid application id" do
+        VCR.use_cassette('client/update_application_invalid_candidate_id') do
+          expect {
+            @client.update_application(
+              1010101,
+              {
+                  source_id: 130370
+              },
+              509925
+            )
+          }.to raise_error(GreenhouseIo::Error)
+        end
+      end
+    end
+
     describe "#scorecards" do
       before do
         VCR.use_cassette('client/scorecards') do


### PR DESCRIPTION
Hello!

I had the need to update a candidate's application but I couldn't any way to do that currently as `Client#applications` is a `GET`-only method, and this is why I implemented a new specialized method called `Client#update_application`.

I couldn't find instructions for VCR conventions. What I did was to use my sandbox account to create them and replace the token with the fake token currently used by the other cassettes, but I'm not sure if you prefer the IDs being faked or not.