### PR TITLE
Adds application time options to PERMITTED_OPTIONS

### DIFF
--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -3,7 +3,7 @@ module GreenhouseIo
     include HTTMultiParty
     include GreenhouseIo::API
 
-    PERMITTED_OPTIONS = [:page, :per_page, :job_id]
+    PERMITTED_OPTIONS = [:page, :per_page, :job_id, :created_after, :created_before, :last_activity_after]
 
     attr_accessor :api_token, :rate_limit, :rate_limit_remaining, :link
     base_uri 'https://harvest.greenhouse.io/v1'


### PR DESCRIPTION
Hello,

Please consider adding `created_after`, `created_before` and `last_activity_after` to permitted options.

Harvest api applications endpoint has very usefull options that allow you to be more specific 
about what kind of applications you want to retrieve and this can save the number of api calls, 
payload sizes and processing time.
https://developers.greenhouse.io/harvest.html#get-list-applications

Thank you for the library @capablemonkey