### PR TITLE
Remove code climate deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,14 @@ rvm:
   - 2.2
   - 2.1
 
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
 script: rake spec
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ group :development do
 end
 
 group :test do
-  gem "codeclimate-test-reporter", group: :test, require: nil
+  gem 'simplecov', require: false
 end
 
 gemspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 require 'rubygems'
 require 'bundler'


### PR DESCRIPTION
WARN -- : This usage of the Code Climate Test Reporter is now deprecated.
Since version 1.0, we now require you to run `SimpleCov` in your test/spec helper,
and then run the provided `codeclimate-test-reporter` binary separately to
report your results to Code Climate.
More information here:
https://github.com/codeclimate/ruby-test-reporter/blob/master/README.md