### PR TITLE
Add base64 encoded api_token as basic auth header to JobBoard#apply_to_job method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tmp
 *.swp
 *.un~
 .tags
+.DS_Store

--- a/greenhouse_io.gemspec
+++ b/greenhouse_io.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.4.0"
-  spec.add_development_dependency "webmock", "~> 1.22.6"
+  spec.add_development_dependency "webmock", "~> 3.3.0"
   spec.add_development_dependency "vcr", "~> 3.0.1"
 end

--- a/lib/greenhouse_io/api/job_board.rb
+++ b/lib/greenhouse_io/api/job_board.rb
@@ -35,7 +35,7 @@ module GreenhouseIo
     end
 
     def apply_to_job(job_form_hash)
-      post_to_job_board_api('/applications', { :body => job_form_hash, :basic_auth => basic_auth })
+      post_to_job_board_api('/applications', { body: job_form_hash, headers: post_headers })
     end
 
     private
@@ -52,6 +52,10 @@ module GreenhouseIo
       else
         raise GreenhouseIo::Error.new(response.code)
       end
+    end
+
+    def post_headers
+      { 'Authorization' => 'Basic ' + Base64.encode64(api_token), 'Content-Type' => 'application/json' }
     end
 
     def post_to_job_board_api(url, options)

--- a/spec/fixtures/cassettes/apply_to_job.yml
+++ b/spec/fixtures/cassettes/apply_to_job.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: https://123FakeToken:@api.greenhouse.io/v1/applications
+    uri: https://api.greenhouse.io/v1/applications
     body:
       encoding: US-ASCII
       string: id=721&first_name=Richard&last_name=Feynman&email=richard123%40test.ga.co
-    headers: {}
+    headers:
+      authorization: Basic MTIzRmFrZVRva2Vu\n
+      content-type: application/json
   response:
     status:
       code: 200
@@ -39,6 +41,6 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! '{"success":"Candidate saved successfully"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 16 Sep 2013 18:25:13 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/activity_feed.yml
+++ b/spec/fixtures/cassettes/client/activity_feed.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates/1/activity_feed
+    uri: https://harvest.greenhouse.io/v1/candidates/1/activity_feed
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -31,6 +33,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{\"notes\":[],\"emails\":[],\"activities\":[{\"created_at\":\"2014-04-22T19:29:14Z\",\"subject\":null,\"body\":\"User One was moved into Preliminary Phone Screen for Bermuda Admissions on 04/01/2014\",\"user\":null},{\"created_at\":\"2014-04-18T18:54:14Z\",\"subject\":null,\"body\":\"User One applied online.\",\"user\":null}]}"
-    http_version: 
+    http_version:
   recorded_at: Wed, 23 Apr 2014 23:42:01 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/all_scorecards.yml
+++ b/spec/fixtures/cassettes/client/all_scorecards.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/scorecards/
+    uri: https://harvest.greenhouse.io/v1/scorecards/
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200

--- a/spec/fixtures/cassettes/client/application.yml
+++ b/spec/fixtures/cassettes/client/application.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/applications/1
+    uri: https://harvest.greenhouse.io/v1/applications/1
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -31,6 +33,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{\"id\":1,\"person_id\":1,\"prospect\":false,\"applied_at\":\"2014-01-23T23:14:23Z\",\"last_activity_at\":\"2014-04-23T23:14:22Z\",\"source\":{\"id\":1,\"public_name\":\"Jobs page on your website\"},\"credited_to\":null,\"jobs\":[{\"id\":4595,\"name\":\"Associate Admissions Producer (Bermuda)\"}],\"status\":\"active\",\"current_stage\":{\"id\":1,\"name\":\"Application Review\"}}"
-    http_version: 
+    http_version:
   recorded_at: Wed, 23 Apr 2014 23:45:19 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/application_by_job_id.yml
+++ b/spec/fixtures/cassettes/client/application_by_job_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/applications?job_id=144371
+    uri: https://harvest.greenhouse.io/v1/applications?job_id=144371
     body:
       encoding: US-ASCII
       string: ''
@@ -134,6 +134,6 @@ http_interactions:
         Review"},"answers":[]},{"id":24709881,"candidate_id":13769693,"prospect":false,"applied_at":"2016-01-26T23:58:09Z","rejected_at":null,"last_activity_at":"2016-01-26T23:59:07Z","source":{"id":2,"public_name":"Jobs
         page on your website"},"credited_to":{"id":158108,"name":"Gordon Zheng"},"rejection_reason":null,"jobs":[{"id":144371,"name":"Good
         Cop"}],"status":"hired","current_stage":null,"answers":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jan 2016 18:09:18 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/applications.yml
+++ b/spec/fixtures/cassettes/client/applications.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/applications
+    uri: https://harvest.greenhouse.io/v1/applications
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -38,6 +40,6 @@ http_interactions:
         Phone Screen\"}},{\"id\":1,\"person_id\":1,\"prospect\":false,\"applied_at\":\"2012-03-17T00:00:00Z\",\"last_activity_at\":\"2013-10-23T16:00:33Z\",\"source\":null,\"credited_to\":null,\"jobs\":[{\"id\":4385,\"name\":\"Educational
         Programs Producer\"}],\"status\":\"accepted\",\"current_stage\":{\"id\":12,\"name\":\"Application
         Review\"}}]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 23 Apr 2014 23:45:19 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/candidate.yml
+++ b/spec/fixtures/cassettes/client/candidate.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates/1
+    uri: https://harvest.greenhouse.io/v1/candidates/1
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -31,6 +33,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{\"id\":1,\"first_name\":\"User\",\"last_name\":\"One\",\"company\":null,\"title\":null,\"created_at\":\"2013-10-17T15:32:26Z\",\"last_activity\":\"2013-10-30T14:37:10Z\",\"photo_url\":null,\"attachments\":[{\"filename\":\"USER_1_Resume_10.13.pdf\",\"url\":\"https://prod-heroku.s3.amazonaws.com/person_attachments/USER_1_Resume_10.13.pdf\",\"type\":\"cover_letter\"},{\"filename\":\"USER_1_Resume_10.13.pdf\",\"url\":\"https://resume.com/USER_1_Resume_10.13.pdf\",\"type\":\"resume\"}],\"application_ids\":[1234],\"phone_numbers\":[{\"value\":\"123-345-5678\",\"type\":\"other\"}],\"addresses\":[],\"email_addresses\":[{\"value\":\"user_one@email.com\",\"type\":\"personal\"}],\"website_addresses\":[],\"social_media_addresses\":[]}"
-    http_version: 
+    http_version:
   recorded_at: Wed, 23 Apr 2014 23:23:02 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/candidates.yml
+++ b/spec/fixtures/cassettes/client/candidates.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates
+    uri: https://harvest.greenhouse.io/v1/candidates
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -33,6 +35,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[{\"id\":1,\"first_name\":\"User\",\"last_name\":\"One\",\"company\":null,\"title\":null,\"created_at\":\"2013-10-17T15:32:26Z\",\"last_activity\":\"2013-10-30T14:37:10Z\",\"photo_url\":null,\"attachments\":[{\"filename\":\"USER_1_Resume_10.13.pdf\",\"url\":\"https://resumes.com/USER_1_Resume_10.13.pdf\",\"type\":\"cover_letter\"},{\"filename\":\"USER_1_Resume_10.13.pdf\",\"url\":\"https://prod-heroku.s3.amazonaws.com/person_attachments/USER_1_Resume_10.13.pdf\",\"type\":\"resume\"}],\"application_ids\":[1234],\"phone_numbers\":[{\"value\":\"123-345-5678\",\"type\":\"other\"}],\"addresses\":[],\"email_addresses\":[{\"value\":\"user_one@email.com\",\"type\":\"personal\"}],\"website_addresses\":[],\"social_media_addresses\":[]}]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 23 Apr 2014 23:23:02 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/create_candidate_note.yml
+++ b/spec/fixtures/cassettes/client/create_candidate_note.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates/1/activity_feed/notes
+    uri: https://harvest.greenhouse.io/v1/candidates/1/activity_feed/notes
     body:
       encoding: UTF-8
       string: '{"user_id":2,"message":"Candidate on vacation","visibility":"public"}'
@@ -37,6 +37,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"created_at":"2016-04-18T19:43:52.534Z","body":"Candidate on vacation","user":{"id":2,"name":"Richard Feynman"},"private":false,"visiblity":"public"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 18 Apr 2016 19:41:44 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/create_candidate_note_invalid_candidate_id.yml
+++ b/spec/fixtures/cassettes/client/create_candidate_note_invalid_candidate_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates/99/activity_feed/notes
+    uri: https://harvest.greenhouse.io/v1/candidates/99/activity_feed/notes
     body:
       encoding: UTF-8
       string: '{"user_id":2,"message":"Candidate on vacation","visibility":"public"}'
@@ -37,6 +37,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"message":"Resource not found"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 18 Apr 2016 19:41:44 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/create_candidate_note_invalid_missing_field.yml
+++ b/spec/fixtures/cassettes/client/create_candidate_note_invalid_missing_field.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates/1/activity_feed/notes
+    uri: https://harvest.greenhouse.io/v1/candidates/1/activity_feed/notes
     body:
       encoding: UTF-8
       string: '{"user_id":2,"visibility":"public"}'
@@ -37,6 +37,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"errors":[{"message":"Missing required field: body","field":"body"}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 18 Apr 2016 19:41:44 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/create_candidate_note_invalid_on_behalf_of.yml
+++ b/spec/fixtures/cassettes/client/create_candidate_note_invalid_on_behalf_of.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates/1/activity_feed/notes
+    uri: https://harvest.greenhouse.io/v1/candidates/1/activity_feed/notes
     body:
       encoding: UTF-8
       string: '{"user_id":2,"message":"Candidate on vacation","visibility":"public"}'
@@ -37,6 +37,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"message":"Resource not found"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 18 Apr 2016 19:41:44 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/create_candidate_note_invalid_user_id.yml
+++ b/spec/fixtures/cassettes/client/create_candidate_note_invalid_user_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates/1/activity_feed/notes
+    uri: https://harvest.greenhouse.io/v1/candidates/1/activity_feed/notes
     body:
       encoding: UTF-8
       string: '{"user_id":99,"message":"Candidate on vacation","visibility":"public"}'
@@ -37,6 +37,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"message":"Resource not found"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 18 Apr 2016 19:41:44 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/current_offer_for_application.yml
+++ b/spec/fixtures/cassettes/client/current_offer_for_application.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/applications/123/offers/current_offer
+    uri: https://harvest.greenhouse.io/v1/applications/123/offers/current_offer
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -35,6 +37,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"id":320847,"version":1,"application_id":123,"created_at":"2016-05-31T19:38:43.623Z","updated_at":"2016-05-31T19:38:56.024Z","sent_at":null,"resolved_at":"2016-05-31T19:38:56.024Z","starts_at":"2016-05-31","status":"accepted","custom_fields":{"benefits":null,"bonus":"1000","current_salary":null,"employment_type":"Full-time","notes":null,"options":"2000","salary":"74111","source_cost":null,"visa_cost":null}}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 31 May 2016 19:48:32 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/department.yml
+++ b/spec/fixtures/cassettes/client/department.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/departments/187
+    uri: https://harvest.greenhouse.io/v1/departments/187
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -31,6 +33,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{\"id\":187,\"name\":\"Engineering\"}"
-    http_version: 
+    http_version:
   recorded_at: Tue, 22 Apr 2014 02:35:58 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/departments.yml
+++ b/spec/fixtures/cassettes/client/departments.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/departments
+    uri: https://harvest.greenhouse.io/v1/departments
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -33,6 +35,6 @@ http_interactions:
       string: "[{\"id\":187,\"name\":\"Engineering\"},{\"id\":188,\"name\":\"Finance\"},{\"id\":364,\"name\":\"HR\"},{\"id\":365,\"name\":\"Marketing\"},{\"id\":366,\"name\":\"Curriculum\"},{\"id\":367,\"name\":\"Enterprise\"},{\"id\":368,\"name\":\"Online\"},{\"id\":369,\"name\":\"Education
         Operations\"},{\"id\":370,\"name\":\"Frontlines\"},{\"id\":371,\"name\":\"Real
         Estate\"},{\"id\":372,\"name\":\"Admissions\"},{\"id\":373,\"name\":\"Design\"},{\"id\":374,\"name\":\"Executive\"},{\"id\":499,\"name\":\"Instruction\"}]"
-    http_version: 
+    http_version:
   recorded_at: Tue, 22 Apr 2014 02:35:25 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/headers.yml
+++ b/spec/fixtures/cassettes/client/headers.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/candidates
+    uri: https://harvest.greenhouse.io/v1/candidates
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -33,6 +35,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[{\"id\":1,\"first_name\":\"User\",\"last_name\":\"One\",\"company\":null,\"title\":null,\"created_at\":\"2013-10-17T15:32:26Z\",\"last_activity\":\"2013-10-30T14:37:10Z\",\"photo_url\":null,\"attachments\":[{\"filename\":\"USER_1_Resume_10.13.pdf\",\"url\":\"https://resumes.com/USER_1_Resume_10.13.pdf\",\"type\":\"cover_letter\"},{\"filename\":\"USER_1_Resume_10.13.pdf\",\"url\":\"https://prod-heroku.s3.amazonaws.com/person_attachments/USER_1_Resume_10.13.pdf\",\"type\":\"resume\"}],\"application_ids\":[1234],\"phone_numbers\":[{\"value\":\"123-345-5678\",\"type\":\"other\"}],\"addresses\":[],\"email_addresses\":[{\"value\":\"user_one@email.com\",\"type\":\"personal\"}],\"website_addresses\":[],\"social_media_addresses\":[]}]"
-    http_version: 
+    http_version:
   recorded_at: Wed, 23 Apr 2014 23:23:02 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/job.yml
+++ b/spec/fixtures/cassettes/client/job.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/jobs/4690
+    uri: https://harvest.greenhouse.io/v1/jobs/4690
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -32,6 +34,6 @@ http_interactions:
       encoding: UTF-8
       string: "{\"id\":4690,\"name\":\"Position Opening 1\",\"requisition_id\":\"\",\"notes\":null,\"status\":\"open\",\"employment_type\":null,\"created_at\":\"2013-11-06T16:26:34Z\",\"opened_at\":\"2013-11-06T16:26:34Z\",\"closed_at\":null,\"departments\":[{\"id\":367,\"name\":\"Enterprise\"}],\"offices\":[{\"id\":214,\"name\":\"New
         York\",\"location\":{\"name\":\"New York, NY\"}}]}"
-    http_version: 
+    http_version:
   recorded_at: Sun, 11 May 2014 23:30:09 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/job_post.yml
+++ b/spec/fixtures/cassettes/client/job_post.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/jobs/4690/job_post
+    uri: https://harvest.greenhouse.io/v1/jobs/4690/job_post
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -44,6 +46,6 @@ http_interactions:
         Profile\",\"type\":\"short_text\",\"values\":[]},{\"required\":false,\"private\":false,\"label\":\"Website\",\"type\":\"short_text\",\"values\":[]},{\"required\":true,\"private\":false,\"label\":\"In
         a few sentences, tell us what makes you unique\",\"type\":\"long_text\",\"values\":[]},{\"required\":true,\"private\":false,\"label\":\"In
         a few sentences, tell us why this job, why now?\",\"type\":\"long_text\",\"values\":[]}]}"
-    http_version: 
+    http_version:
   recorded_at: Sun, 11 May 2014 23:33:43 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/jobs.yml
+++ b/spec/fixtures/cassettes/client/jobs.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/jobs
+    uri: https://harvest.greenhouse.io/v1/jobs
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -34,6 +36,6 @@ http_interactions:
       encoding: UTF-8
       string: "[{\"id\":4690,\"name\":\"Position Opening 1\",\"requisition_id\":\"\",\"notes\":null,\"status\":\"open\",\"employment_type\":null,\"created_at\":\"2013-11-06T16:26:34Z\",\"opened_at\":\"2013-11-06T16:26:34Z\",\"closed_at\":null,\"departments\":[{\"id\":367,\"name\":\"Enterprise\"}],\"offices\":[{\"id\":214,\"name\":\"New
         York\",\"location\":{\"name\":\"New York, NY\"}}]}]"
-    http_version: 
+    http_version:
   recorded_at: Sun, 11 May 2014 23:28:33 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/offer.yml
+++ b/spec/fixtures/cassettes/client/offer.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/offers/221598
+    uri: https://harvest.greenhouse.io/v1/offers/221598
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: '{"id":221598,"version":1,"application_id":21708586,"created_at":"2016-01-26T23:57:28Z","sent_at":null,"resolved_at":"2016-01-26T23:57:35Z","starts_at":"2016-01-26","status":"rejected","custom_fields":{"benefits":"Full
         Medical","bonus":"1000","current_salary":"25000","employment_type":"Full-time","notes":"He
         was very excited.","options":"2000","salary":"31000","source_cost":null,"visa_cost":"200"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 27 Jan 2016 00:27:44 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/offers.yml
+++ b/spec/fixtures/cassettes/client/offers.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/offers
+    uri: https://harvest.greenhouse.io/v1/offers
     body:
       encoding: US-ASCII
       string: ''
@@ -46,6 +46,6 @@ http_interactions:
         Medical","bonus":"1000","current_salary":"25000","employment_type":"Full-time","notes":"He
         was very excited.","options":"2000","salary":"31000","source_cost":null,"visa_cost":"200"}},{"id":221603,"version":1,"application_id":21880506,"created_at":"2016-01-26T23:59:27Z","sent_at":null,"resolved_at":null,"starts_at":"2016-01-30","status":"unresolved","custom_fields":{"benefits":null,"bonus":"1000","current_salary":null,"employment_type":"Full-time","notes":null,"options":"2000","salary":"60000","source_cost":null,"visa_cost":null}},{"id":163831,"version":1,"application_id":22109366,"created_at":"2015-11-30T22:29:19Z","sent_at":null,"resolved_at":"2015-11-30T22:29:52Z","starts_at":"2015-12-01","status":"accepted","custom_fields":{"benefits":null,"bonus":null,"current_salary":null,"employment_type":"Full-time","notes":null,"options":null,"salary":"20000","source_cost":null,"visa_cost":null}},{"id":221601,"version":1,"application_id":24709881,"created_at":"2016-01-26T23:58:48Z","sent_at":null,"resolved_at":"2016-01-26T23:59:07Z","starts_at":"2016-01-19","status":"accepted","custom_fields":{"benefits":null,"bonus":"1000","current_salary":"500","employment_type":"Full-time","notes":"He
         didn''t seem too impressed.","options":"100","salary":"74111","source_cost":"200","visa_cost":null}}]'
-    http_version: 
+    http_version:
   recorded_at: Tue, 26 Jan 2016 23:59:58 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/offers_for_application.yml
+++ b/spec/fixtures/cassettes/client/offers_for_application.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/applications/123/offers
+    uri: https://harvest.greenhouse.io/v1/applications/123/offers
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -35,6 +37,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"id":320847,"version":1,"application_id":123,"created_at":"2016-05-31T19:38:43.623Z","updated_at":"2016-05-31T19:38:56.024Z","sent_at":null,"resolved_at":"2016-05-31T19:38:56.024Z","starts_at":"2016-05-31","status":"accepted","custom_fields":{"benefits":null,"bonus":"1000","current_salary":null,"employment_type":"Full-time","notes":null,"options":"2000","salary":"74111","source_cost":null,"visa_cost":null}}]'
-    http_version: 
+    http_version:
   recorded_at: Tue, 31 May 2016 19:39:22 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/client/office.yml
+++ b/spec/fixtures/cassettes/client/office.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/offices/220
+    uri: https://harvest.greenhouse.io/v1/offices/220
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -31,6 +33,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{\"id\":220,\"name\":\"Boston\",\"location\":{\"name\":\"Boston, MA\"}}"
-    http_version: 
+    http_version:
   recorded_at: Mon, 21 Apr 2014 23:59:11 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/offices.yml
+++ b/spec/fixtures/cassettes/client/offices.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/offices
+    uri: https://harvest.greenhouse.io/v1/offices
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -41,6 +43,6 @@ http_interactions:
         WA\"}},{\"id\":857,\"name\":\"Chicago\",\"location\":{\"name\":\"Chicago,
         IL, United States\"}},{\"id\":858,\"name\":\"Atlanta\",\"location\":{\"name\":\"Atlanta,
         GA, United States\"}}]"
-    http_version: 
+    http_version:
   recorded_at: Mon, 21 Apr 2014 23:39:41 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/scheduled_interviews.yml
+++ b/spec/fixtures/cassettes/client/scheduled_interviews.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/applications/1/scheduled_interviews
+    uri: https://harvest.greenhouse.io/v1/applications/1/scheduled_interviews
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -33,6 +35,6 @@ http_interactions:
       string: "[{\"id\":435294,\"starts_at\":\"2014-01-10T21:00:00Z\",\"ends_at\":\"2014-01-10T21:15:00Z\",\"location\":null,\"status\":\"complete\",\"interview\":{\"id\":85265,\"name\":\"Task
         Follow Up\"},\"organizer\":{\"id\":3850,\"name\":\"Test User\"},\"interviewers\":[{\"id\":3850,\"name\":\"Test User\",\"email\":null}]},{\"id\":435293,\"starts_at\":\"2014-01-11T13:00:00Z\",\"ends_at\":\"2014-01-11T13:45:00Z\",\"location\":\"Phone\",\"status\":\"complete\",\"interview\":{\"id\":39539,\"name\":\"Preliminary
         Screening Call\"},\"organizer\":{\"id\":3850,\"name\":\"Test User\"},\"interviewers\":[{\"id\":3850,\"name\":\"Test User\",\"email\":null}]}]"
-    http_version: 
+    http_version:
   recorded_at: Sun, 11 May 2014 23:21:20 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/scorecards.yml
+++ b/spec/fixtures/cassettes/client/scorecards.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/applications/1/scorecards
+    uri: https://harvest.greenhouse.io/v1/applications/1/scorecards
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -32,6 +34,6 @@ http_interactions:
       encoding: UTF-8
       string: "[{\"interview\":\"Task Follow Up\",\"interviewed_at\":\"2014-01-13T00:00:00Z\",\"submitted_by\":{\"id\":3850,\"name\":\"Test User\"},\"submitted_at\":\"2014-01-13T22:06:55Z\",\"overall_recommendation\":\"no_decision\",\"ratings\":{\"definitely_not\":[],\"no\":[],\"mixed\":[],\"yes\":[],\"strong_yes\":[]},\"questions\":[{\"id\":null,\"question\":\"Key
         Take-Aways\",\"answer\":\"\"},{\"id\":null,\"question\":\"Private Notes\",\"answer\":\"\"}]}]"
-    http_version: 
+    http_version:
   recorded_at: Sun, 11 May 2014 06:50:37 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/source.yml
+++ b/spec/fixtures/cassettes/client/source.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/sources/1
+    uri: https://harvest.greenhouse.io/v1/sources/1
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -34,6 +36,6 @@ http_interactions:
       encoding: UTF-8
       string: "{\"id\":1,\"name\":\"Customer newsletter\",\"type\":{\"id\":1,\"name\":\"Company
         marketing\"}}"
-    http_version: 
+    http_version:
   recorded_at: Sun, 11 May 2014 23:46:49 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/sources.yml
+++ b/spec/fixtures/cassettes/client/sources.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/sources
+    uri: https://harvest.greenhouse.io/v1/sources
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -32,6 +34,6 @@ http_interactions:
       encoding: UTF-8
       string: "[{\"id\":1,\"name\":\"Customer newsletter\",\"type\":{\"id\":1,\"name\":\"Company
         marketing\"}}]"
-    http_version: 
+    http_version:
   recorded_at: Sun, 11 May 2014 23:39:55 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/stages.yml
+++ b/spec/fixtures/cassettes/client/stages.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/jobs/4690/stages
+    uri: https://harvest.greenhouse.io/v1/jobs/4690/stages
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -31,6 +33,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[{\"id\":31416,\"name\":\"Offer\",\"interviews\":[]}]"
-    http_version: 
+    http_version:
   recorded_at: Sun, 11 May 2014 23:32:18 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/user.yml
+++ b/spec/fixtures/cassettes/client/user.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/users/10327
+    uri: https://harvest.greenhouse.io/v1/users/10327
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -31,6 +33,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "{\"id\":10327,\"name\":\"Test User 1\"}"
-    http_version: 
+    http_version:
   recorded_at: Sun, 11 May 2014 23:37:55 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/client/users.yml
+++ b/spec/fixtures/cassettes/client/users.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://123FakeToken:@harvest.greenhouse.io/v1/users
+    uri: https://harvest.greenhouse.io/v1/users
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -33,6 +35,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "[{\"id\":10327,\"name\":\"Test User 1\",\"disabled\":false,\"site_admin\":false,\"emails\":[\"test_user@email.com\"]}]"
-    http_version: 
+    http_version:
   recorded_at: Sun, 11 May 2014 23:36:21 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/department.yml
+++ b/spec/fixtures/cassettes/department.yml
@@ -6,7 +6,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -40,6 +42,6 @@ http_interactions:
         developer","updated_at":"2013-09-12T21:01:50Z","location":{"name":"New York,
         NY"},"absolute_url":"http://boards.greenhouse.io/generalassembly/jobs/721"},{"id":722,"title":"Finance
         Analyst","updated_at":"2013-09-12T21:01:50Z","location":{"name":"New York"},"absolute_url":"http://boards.greenhouse.io/generalassembly/jobs/722"}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 16 Sep 2013 16:10:28 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/departments.yml
+++ b/spec/fixtures/cassettes/departments.yml
@@ -6,7 +6,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -40,6 +42,6 @@ http_interactions:
         Analyst","updated_at":"2013-09-12T21:01:50Z","location":{"name":"New York"},"absolute_url":"http://boards.greenhouse.io/generalassembly/jobs/722"}]},{"id":0,"name":"No
         Department","jobs":[{"id":721,"title":"Application developer","updated_at":"2013-09-12T21:01:50Z","location":{"name":"New
         York, NY"},"absolute_url":"http://boards.greenhouse.io/generalassembly/jobs/721"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 16 Sep 2013 16:08:59 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/invalid_application.yml
+++ b/spec/fixtures/cassettes/invalid_application.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: https://123FakeToken:@api.greenhouse.io/v1/applications
+    uri: https://api.greenhouse.io/v1/applications
     body:
       encoding: US-ASCII
       string: id=721&question_2720=not_required
-    headers: {}
+    headers:
+      authorization: Basic MTIzRmFrZVRva2Vu\n
+      content-type: application/json
   response:
     status:
       code: 200
@@ -38,6 +40,6 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"error":"Failed to save person","reason":"Validation failed: Either
         a name or email address is required."}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 17 Sep 2013 14:47:24 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/invalid_application_id.yml
+++ b/spec/fixtures/cassettes/invalid_application_id.yml
@@ -2,11 +2,13 @@
 http_interactions:
 - request:
     method: post
-    uri: https://123FakeToken:@api.greenhouse.io/v1/applications
+    uri: https://api.greenhouse.io/v1/applications
     body:
       encoding: US-ASCII
       string: id=456&first_name=Gob&last_name=Bluth&email=gob%40bluth.com
-    headers: {}
+    headers:
+      authorization: Basic MTIzRmFrZVRva2Vu\n
+      content-type: application/json
   response:
     status:
       code: 200
@@ -39,6 +41,6 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! '{"error":"Failed to save person","reason":"Job application not live"}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 17 Sep 2013 14:41:59 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/invalid_id.yml
+++ b/spec/fixtures/cassettes/invalid_id.yml
@@ -6,7 +6,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 400
@@ -35,6 +37,6 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! '{"error":"Could not find a job with id ''123'' for generalassembly"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 16 Sep 2013 22:55:58 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/invalid_organization.yml
+++ b/spec/fixtures/cassettes/invalid_organization.yml
@@ -6,7 +6,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 400
@@ -35,6 +37,6 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! '{"error":"Could not find a job board with token ''not-real-inc''"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 16 Sep 2013 22:43:02 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/job.yml
+++ b/spec/fixtures/cassettes/job.yml
@@ -6,7 +6,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -75,6 +77,6 @@ http_interactions:
         +1 cillum. VHS trust fund mollit, cliche wolf dreamcatcher salvia tattooed
         do thundercats carles.&lt;/p&gt;","updated_at":"2013-09-12T21:01:50Z","location":{"name":"New
         York, NY"},"absolute_url":"http://boards.greenhouse.io/generalassembly/jobs/721","departments":[],"offices":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 16 Sep 2013 16:16:24 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/job_with_questions.yml
+++ b/spec/fixtures/cassettes/job_with_questions.yml
@@ -6,7 +6,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -80,6 +82,6 @@ http_interactions:
         Letter","fields":[{"name":"cover_letter","type":"input_file"},{"name":"cover_letter_text","type":"textarea"}]},{"required":false,"label":"LinkedIn
         Profile","fields":[{"name":"question_2720","type":"input_text"}]},{"required":false,"label":"Website","fields":[{"name":"question_2721","type":"input_text"}]},{"required":false,"label":"How
         did you hear about this job?","fields":[{"name":"question_2722","type":"input_text"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 16 Sep 2013 16:18:12 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/jobs.yml
+++ b/spec/fixtures/cassettes/jobs.yml
@@ -6,7 +6,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -39,6 +41,6 @@ http_interactions:
       string: ! '{"jobs":[{"id":721,"title":"Application developer","updated_at":"2013-09-12T21:01:50Z","location":{"name":"New
         York, NY"},"absolute_url":"http://boards.greenhouse.io/generalassembly/jobs/721"},{"id":722,"title":"Finance
         Analyst","updated_at":"2013-09-12T21:01:50Z","location":{"name":"New York"},"absolute_url":"http://boards.greenhouse.io/generalassembly/jobs/722"}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 16 Sep 2013 16:13:48 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/jobs_with_content.yml
+++ b/spec/fixtures/cassettes/jobs_with_content.yml
@@ -6,7 +6,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -113,6 +115,6 @@ http_interactions:
         +1 cillum. VHS trust fund mollit, cliche wolf dreamcatcher salvia tattooed
         do thundercats carles.&lt;/p&gt;","updated_at":"2013-09-12T21:01:50Z","location":{"name":"New
         York"},"absolute_url":"http://boards.greenhouse.io/generalassembly/jobs/722","departments":[{"id":188,"name":"Finance"}],"offices":[]}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 16 Sep 2013 16:15:02 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/office.yml
+++ b/spec/fixtures/cassettes/office.yml
@@ -6,7 +6,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -40,6 +42,6 @@ http_interactions:
         Analyst","updated_at":"2013-09-12T21:01:50Z","location":{"name":"New York"},"absolute_url":"http://boards.greenhouse.io/generalassembly/jobs/722"}]},{"id":0,"name":"No
         Department","jobs":[{"id":721,"title":"Application developer","updated_at":"2013-09-12T21:01:50Z","location":{"name":"New
         York, NY"},"absolute_url":"http://boards.greenhouse.io/generalassembly/jobs/721"}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 16 Sep 2013 16:04:22 GMT
 recorded_with: VCR 2.5.0

--- a/spec/fixtures/cassettes/offices.yml
+++ b/spec/fixtures/cassettes/offices.yml
@@ -6,7 +6,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    headers: {}
+    headers:
+      Authorization:
+      - Basic MTIzRmFrZVRva2VuOg==
   response:
     status:
       code: 200
@@ -40,6 +42,6 @@ http_interactions:
         Analyst","updated_at":"2013-09-12T21:01:50Z","location":{"name":"New York"},"absolute_url":"http://boards.greenhouse.io/generalassembly/jobs/722"}]},{"id":0,"name":"No
         Department","jobs":[{"id":721,"title":"Application developer","updated_at":"2013-09-12T21:01:50Z","location":{"name":"New
         York, NY"},"absolute_url":"http://boards.greenhouse.io/generalassembly/jobs/721"}]}]}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 16 Sep 2013 16:04:21 GMT
 recorded_with: VCR 2.5.0

--- a/spec/greenhouse_io/api/job_board_spec.rb
+++ b/spec/greenhouse_io/api/job_board_spec.rb
@@ -137,6 +137,15 @@ describe GreenhouseIo::JobBoard do
       end
     end
 
+    describe "#post_headers" do
+      it "contains necessary headers for apply_to_job method" do
+        expect(@client.send(:post_headers).fetch('Authorization')).not_to be_nil
+        expect(@client.send(:post_headers).fetch('Authorization')).to eq('Basic ' + Base64.encode64(@client.api_token))
+        expect(@client.send(:post_headers).fetch('Content-Type')).not_to be_nil
+        expect(@client.send(:post_headers).fetch('Content-Type')).to eq('application/json')
+      end
+    end
+
     describe "#apply_to_job" do
       it "posts an application to a specified job" do
         VCR.use_cassette('apply_to_job') do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 require 'rubygems'
 require 'bundler'


### PR DESCRIPTION
POST requests to Job Applications endpoint require api_token to be base64 encoded, and Content-Type to be set as 'application/json'.
Being able to run specs required updating webmock version and codeclimate ruby-test-reporter config.