### PR TITLE
docs: add gem name to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the gem to your application's Gemfile:
 
 Or install it yourself as:
 
-    $ gem install
+    $ gem install greenhouse_io
 
 ## API Documentation
 


### PR DESCRIPTION
Looks like the name was left off since this step suggests: 

> Or install it yourself as:

I suppose it could be that line could be reworded, `And then install it with the command:`