### PR TITLE
Add ability to create or delete candidates

### DIFF
--- a/lib/greenhouse_io/api.rb
+++ b/lib/greenhouse_io/api.rb
@@ -8,6 +8,10 @@ module GreenhouseIo
       self.class.post(url, options)
     end
 
+    def patch_response(url, options)
+      self.class.patch(url, options)
+    end
+
     def delete_response(url, options)
       self.class.delete(url, options)
     end

--- a/lib/greenhouse_io/api.rb
+++ b/lib/greenhouse_io/api.rb
@@ -8,6 +8,10 @@ module GreenhouseIo
       self.class.post(url, options)
     end
 
+    def delete_response(url, options)
+      self.class.delete(url, options)
+    end
+
     def parse_json(response)
       JSON.parse(response.body, symbolize_names: GreenhouseIo.configuration.symbolize_keys)
     end

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -133,6 +133,8 @@ module GreenhouseIo
 
       if response.code == 200
         parse_json(response)
+      elsif response.code == 201
+        parse_json(response)
       else
         raise GreenhouseIo::Error.new(response.code)
       end

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -28,10 +28,6 @@ module GreenhouseIo
       get_from_harvest_api "/candidates#{path_id(id)}", options
     end
 
-    def candidate(id=nil, options={})
-      get_from_harvest_api "/candidates#{path_id(id)}", options
-    end
-
     def activity_feed(id, options = {})
       get_from_harvest_api "/candidates/#{id}/activity_feed", options
     end

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -41,7 +41,7 @@ module GreenhouseIo
 
     def delete_candidate(candidate_id, on_behalf_of)
       delete_with_harvest_api \
-        "/candidates/#{id}",
+        "/candidates/#{candidate_id}",
         { 'On-Behalf-Of' => on_behalf_of.to_s }
     end
 

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -132,6 +132,22 @@ module GreenhouseIo
       end
     end
 
+    def delete_with_harvest_api(url, body, headers)
+      response = delete_response(url, {
+        :body => JSON.dump(body),
+        :basic_auth => basic_auth,
+        :headers => headers
+      })
+
+      set_headers_info(response.headers)
+
+      if response.code == 200
+        parse_json(response)
+      else
+        raise GreenhouseIo::Error.new(response.code)
+      end
+    end
+
     def set_headers_info(headers)
       self.rate_limit = headers['x-ratelimit-limit'].to_i
       self.rate_limit_remaining = headers['x-ratelimit-remaining'].to_i

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -136,7 +136,7 @@ module GreenhouseIo
       elsif response.code == 201
         parse_json(response)
       else
-        raise GreenhouseIo::Error.new(response.code)
+        raise GreenhouseIo::Error.new("Response code: #{response.code}, message: #{response.body}")
       end
     end
 

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -39,6 +39,12 @@ module GreenhouseIo
         { 'On-Behalf-Of' => on_behalf_of.to_s }
     end
 
+    def delete_candidate(candidate_id, on_behalf_of)
+      delete_with_harvest_api \
+        "/candidates/#{id}",
+        { 'On-Behalf-Of' => on_behalf_of.to_s }
+    end
+
     def create_candidate_note(candidate_id, note_hash, on_behalf_of)
       post_to_harvest_api(
         "/candidates/#{candidate_id}/activity_feed/notes",

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -28,6 +28,10 @@ module GreenhouseIo
       get_from_harvest_api "/candidates#{path_id(id)}", options
     end
 
+    def candidate(id=nil, options={})
+      get_from_harvest_api "/candidates#{path_id(id)}", options
+    end
+
     def activity_feed(id, options = {})
       get_from_harvest_api "/candidates/#{id}/activity_feed", options
     end
@@ -96,7 +100,7 @@ module GreenhouseIo
 
     def get_from_harvest_api(url, options = {})
       response = get_response(url, {
-        :query => permitted_options(options), 
+        :query => permitted_options(options),
         :basic_auth => basic_auth
       })
 

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -118,12 +118,30 @@ module GreenhouseIo
       if response.code == 200
         parse_json(response)
       else
-        raise GreenhouseIo::Error.new(response.code)
+        raise GreenhouseIo::Error.new("Response code: #{response.code}, message: #{response.body}")
       end
     end
 
     def post_to_harvest_api(url, body, headers)
       response = post_response(url, {
+        :body => JSON.dump(body),
+        :basic_auth => basic_auth,
+        :headers => headers
+      })
+
+      set_headers_info(response.headers)
+
+      if response.code == 200
+        parse_json(response)
+      elsif response.code == 201
+        parse_json(response)
+      else
+        raise GreenhouseIo::Error.new("Response code: #{response.code}, message: #{response.body}")
+      end
+    end
+
+    def patch_with_harvest_api(url, body, headers)
+      response = patch_response(url, {
         :body => JSON.dump(body),
         :basic_auth => basic_auth,
         :headers => headers
@@ -150,8 +168,10 @@ module GreenhouseIo
 
       if response.code == 200
         parse_json(response)
+      elsif response.code == 201
+        parse_json(response)
       else
-        raise GreenhouseIo::Error.new(response.code)
+        raise GreenhouseIo::Error.new("Response code: #{response.code}, message: #{response.body}")
       end
     end
 

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -138,9 +138,8 @@ module GreenhouseIo
       end
     end
 
-    def delete_with_harvest_api(url, body, headers)
+    def delete_with_harvest_api(url, headers)
       response = delete_response(url, {
-        :body => JSON.dump(body),
         :basic_auth => basic_auth,
         :headers => headers
       })

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -32,6 +32,13 @@ module GreenhouseIo
       get_from_harvest_api "/candidates/#{id}/activity_feed", options
     end
 
+    def create_candidate(candidate_hash, on_behalf_of)
+      post_harvest_api \
+        "/candidates",
+        candidate_hash,
+        { 'On-Behalf-Of' => on_behalf_of.to_s }
+    end
+
     def create_candidate_note(candidate_id, note_hash, on_behalf_of)
       post_to_harvest_api(
         "/candidates/#{candidate_id}/activity_feed/notes",

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -33,7 +33,7 @@ module GreenhouseIo
     end
 
     def create_candidate(candidate_hash, on_behalf_of)
-      post_harvest_api \
+      post_to_harvest_api \
         "/candidates",
         candidate_hash,
         { 'On-Behalf-Of' => on_behalf_of.to_s }


### PR DESCRIPTION
Hi, thanks for creating this repo, we've found it to be useful for interacting with the Greenhouse API.

This PR is for your consideration. It adds support for the following API endpoints:

 - [POST candidate](https://developers.greenhouse.io/candidate-ingestion.html#post-candidates)
 - [DELETE candidate](https://developers.greenhouse.io/harvest.html#delete-delete-candidate)

This also adds some more verbosity to error messages and implements a method for PATCH (currently unused, but various endpoints use this method).

What do you think about these changes? Thanks!