### PR TITLE
Update gemspec authors, email, and post-install message

### DIFF
--- a/greenhouse_io.gemspec
+++ b/greenhouse_io.gemspec
@@ -6,12 +6,21 @@ require 'greenhouse_io/version'
 Gem::Specification.new do |spec|
   spec.name          = "greenhouse_io"
   spec.version       = GreenhouseIo::VERSION
-  spec.authors       = ["Greenhouse Software", "Adrian Bautista"]
-  spec.email         = ["support@greenhouse.io", "adrianbautista8@gmail.com"]
+  spec.authors       = %w(Greenhouse Software)
+  spec.email         = %w(tech@greenhouse.io)
   spec.description   = %q{Ruby bindings for the greenhouse.io Harvest API and Job Board API}
   spec.summary       = %q{Ruby bindings for the greenhouse.io Harvest API and Job Board API}
   spec.license       = "MIT"
   spec.homepage      = "https://github.com/grnhse/greenhouse_io"
+
+  spec.post_install_message = %q{
+    greenhouse_io will be removed from Rubygems.org on Friday, April 3, 2026.
+    Please install using a direct link to the Github repo:
+    
+    gem "greenhouse_io", git: "git@github.com:grnhse/greenhouse_io.git", branch: "master"
+
+    Additionally, Harvest V1/V2 will be decomissioned in August 2026.
+  }
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Updated authors and email for the gem specification. Added a post-install message regarding the removal of the gem from Rubygems.org and decommissioning of Harvest V1/V2.