### PR TITLE
Modify post-install message in gemspec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 This project follows [semantic versioning](http://semver.org/).  This changelog follows suggestions from [keepachangelog.com](http://keepachangelog.com/).
 
+## Version 2.5.2
+Released 2026-01-21.
+
+#### Changed
+- Edited post-install message
+
 ## Version 2.5.1
 Released 2026-01-21.
 

--- a/greenhouse_io.gemspec
+++ b/greenhouse_io.gemspec
@@ -14,12 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/grnhse/greenhouse_io"
 
   spec.post_install_message = %q{
-    greenhouse_io will be removed from Rubygems.org on Friday, April 3, 2026.
-    Please install using a direct link to the Github repo:
-    
-    gem "greenhouse_io", git: "git@github.com:grnhse/greenhouse_io.git", branch: "master"
-
-    Additionally, Harvest V1/V2 will be decomissioned in August 2026.
+    WARNING: Additionally, Harvest V1/V2 will be decomissioned in August 2026.
   }
 
   spec.files         = `git ls-files`.split($/)

--- a/lib/greenhouse_io/version.rb
+++ b/lib/greenhouse_io/version.rb
@@ -1,3 +1,3 @@
 module GreenhouseIo
-  VERSION = "2.5.1"
+  VERSION = "2.5.2"
 end


### PR DESCRIPTION
Updated post-install message to include warning about Harvest V1/V2 decommissioning.